### PR TITLE
[WASM] Restore lost _withStackOrHeapBuffer implementation

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -505,7 +505,18 @@ static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuf
     return true;
 }
 
-#if !TARGET_OS_WASI
+#if TARGET_OS_WASI
+static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+    _ConditionalAllocationBuffer buffer;
+    buffer.capacity = amount;
+    buffer.onStack = false;
+    buffer.memory = malloc(buffer.capacity);
+    if (buffer.memory == NULL) { return false; }
+    applier(&buffer);
+    free(buffer.memory);
+    return true;
+}
+#else
 static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
     _ConditionalAllocationBuffer buffer;
 #if TARGET_OS_MAC


### PR DESCRIPTION
Resolve https://github.com/swiftwasm/swift/issues/1824#issuecomment-698287232


```
$ swift build -c debug --build-tests --destination wasm32-unknown-wasi.json 
wasm-ld: error: /path/to/swift-wasm-DEVELOPMENT-SNAPSHOT-2020-10-05-a/usr/lib/swift_static/wasi/libFoundation.a(Data.swift.obj): undefined symbol: _withStackOrHeapBuffer
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
[7/8] Linking wpkgPackageTests.xctest
```