### PR TITLE
Add WASI specific modulemap for linked libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,18 @@ install(DIRECTORY
         DESTINATION
           ${swift_lib_dir}/CoreFoundation
         FILES_MATCHING PATTERN "*.h")
-install(FILES
-          CoreFoundation/Base.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>module.map
-        DESTINATION
-          ${swift_lib_dir}/CoreFoundation)
+if(CMAKE_SYSTEM_NAME STREQUAL WASI)
+  install(FILES
+            CoreFoundation/Base.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>wasm32-unknown-wasi.modulemap
+          DESTINATION
+            ${swift_lib_dir}/CoreFoundation
+          RENAME module.map)
+else()
+  install(FILES
+            CoreFoundation/Base.subproj/$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:static/>module.map
+          DESTINATION
+            ${swift_lib_dir}/CoreFoundation)
+endif()
 install(DIRECTORY
           ${CMAKE_CURRENT_BINARY_DIR}/CFURLSessionInterface.framework/Headers/
         DESTINATION

--- a/CoreFoundation/Base.subproj/static/wasm32-unknown-wasi.modulemap
+++ b/CoreFoundation/Base.subproj/static/wasm32-unknown-wasi.modulemap
@@ -1,0 +1,10 @@
+module CoreFoundation [extern_c] [system] {
+    umbrella header "CoreFoundation.h"
+    explicit module CFPlugInCOM { header "CFPlugInCOM.h" }
+
+    link "CoreFoundation"
+    link "uuid"
+
+    link "BlocksRuntime"
+    link "icui18n"
+}


### PR DESCRIPTION
For wasi targeted CoreFoundation requires BlocksRuntime and icui18n to be linked statically and we link them using `destination.json` for SwiftPM.

But Swift compiler can automatically link them if there is `link` declarations in modulemap. After this patch, we don't need those linker flags in destination.json.

