### PR TITLE
Add swiftcc attribute to swift_retain to resolve signature mismatch issue

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -59,6 +59,12 @@
 #define __has_extension(x) 0
 #endif
 
+#if __has_attribute(swiftcall)
+#define CF_CC_swift __attribute__((swiftcall))
+#else
+#define CF_CC_swift
+#endif
+
 #if defined(__GNUC__) || TARGET_OS_WIN32
 #include <stdint.h>
 #include <stdbool.h>

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1487,6 +1487,7 @@ CF_PRIVATE int asprintf(char **ret, const char *format, ...) {
 #if DEPLOYMENT_RUNTIME_SWIFT
 #include <fcntl.h>
 
+CF_CC_swift
 extern void *swift_retain(void *);
 extern void swift_release(void *);
 

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1362,6 +1362,7 @@ int DllMain( HINSTANCE hInstance, DWORD dwReason, LPVOID pReserved ) {
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
+CF_CC_swift
 extern void *swift_retain(void *);
 #endif
 


### PR DESCRIPTION
This issue was revealed while upgrading clang version in https://github.com/swiftwasm/swift/pull/2410


The swift_retain has been attributed with swiftcc since
https://github.com/swiftwasm/swift/commit/b565d02739ffce1093c4535f61de931b934cfb7b

Ideally the swiftcc attribute should be removed and swift side caller
should call it with C calling convention, but there is no way to declare
C function signature in Swift (except for importing from ClangImporter).

So this patch is a temporary workaround. Please follow the related forum
thread https://forums.swift.org/t/formalizing-cdecl/40677