### PR TITLE
Ensure last chunk of XML data is parsed

### DIFF
--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -603,10 +603,7 @@ open class XMLParser : NSObject {
         var result = true
         var chunkStart = 0
         var chunkEnd = min(_chunkSize, data.count)
-        while result {
-            if chunkStart >= data.count || chunkEnd >= data.count {
-                break
-            }
+        while result && chunkStart != chunkEnd {
             let chunk = data[chunkStart..<chunkEnd]
             result = parseData(chunk)
             chunkStart = chunkEnd


### PR DESCRIPTION
Fixes case where last chunk was skipped during parse

Appears some refactoring in [this PR](https://github.com/swiftwasm/swift-corelibs-foundation/pull/373/files) may have introduced this behavior. 

I was unable to get the test suites running locally after following the "Getting Started" guide- Are there test cases that I can add somewhere to cover this? The bug is exhibited when parsing any XML document. I noticed this when parsing a document smaller than `_chunkSize`