### PR TITLE
Compile more of FileHandle.swift for IO functionality

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -83,6 +83,8 @@
 #include <sys/stat.h>
 #endif // not __NR_statx
 
+#elif TARGET_OS_WASI
+#include <sys/stat.h>
 #endif // TARGET_OS_LINUX
 
 #include <stdlib.h>
@@ -552,7 +554,7 @@ CF_CROSS_PLATFORM_EXPORT CFIndex __CFCharDigitValue(UniChar ch);
 
 #if TARGET_OS_WIN32
 CF_CROSS_PLATFORM_EXPORT int _CFOpenFileWithMode(const unsigned short *path, int opts, mode_t mode);
-#elif !TARGET_OS_WASI
+#else
 CF_CROSS_PLATFORM_EXPORT int _CFOpenFileWithMode(const char *path, int opts, mode_t mode);
 #endif
 CF_CROSS_PLATFORM_EXPORT void *_CFReallocf(void *ptr, size_t size);

--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -2030,7 +2030,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-#if !os(WASI)
     /// Initialize a `Data` with the contents of a `URL`.
     ///
     /// - parameter url: The `URL` to read.
@@ -2043,7 +2042,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return Data(bytes: d.bytes, count: d.length)
         }
     }
-#endif
     
     /// Initialize a `Data` from a Base-64 encoded String using the given options.
     ///

--- a/Sources/Foundation/FoundationErrors.swift
+++ b/Sources/Foundation/FoundationErrors.swift
@@ -168,7 +168,6 @@ public var NSCoderReadCorruptError: Int                      { return CocoaError
 
 public var NSCoderValueNotFoundError: Int                    { return CocoaError.Code.coderValueNotFound.rawValue }
 
-#if !os(WASI)
 internal func _NSErrorWithErrno(_ posixErrno : Int32, reading : Bool, path : String? = nil, url : URL? = nil, extraUserInfo : [String : Any]? = nil) -> NSError {
     var cocoaError : CocoaError.Code
     if reading {
@@ -206,7 +205,6 @@ internal func _NSErrorWithErrno(_ posixErrno : Int32, reading : Bool, path : Str
     
     return NSError(domain: NSCocoaErrorDomain, code: cocoaError.rawValue, userInfo: userInfo)
 }
-#endif
 
 #if os(Windows)
 // The codes in this domain are codes returned by GetLastError in the Windows SDK (in WinError.h):

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -151,7 +151,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         _init(bytes: bytes, length: length, copy: false, deallocator: deallocator)
     }
 
-#if !os(WASI)
     /// Initializes a data object with the contents of the file at a given path.
     public init(contentsOfFile path: String, options readOptionsMask: ReadingOptions = []) throws {
         super.init()
@@ -174,7 +173,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return nil
         }
     }
-#endif
 
     /// Initializes a data object with the contents of another data object.
     public init(data: Data) {
@@ -184,7 +182,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-#if !os(WASI)
     /// Initializes a data object with the data from the location specified by a given URL.
     public init(contentsOf url: URL, options readOptionsMask: ReadingOptions = []) throws {
         super.init()
@@ -217,7 +214,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return try _NSNonfileURLContentLoader.current.contentsOf(url: url)
         }
     }
-#endif
 
     /// Initializes a data object with the given Base64 encoded string.
     public init?(base64Encoded base64String: String, options: Base64DecodingOptions = []) {
@@ -433,7 +429,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-#if !os(WASI)
     internal static func readBytesFromFileWithExtendedAttributes(_ path: String, options: ReadingOptions) throws -> NSDataReadResult {
         guard let handle = FileHandle(path: path, flags: O_RDONLY, createMode: 0) else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
@@ -443,6 +438,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     }
 
 
+#if !os(WASI)
     /// Writes the data object's bytes to the file specified by a given path.
     open func write(toFile path: String, options writeOptionsMask: WritingOptions = []) throws {
 
@@ -1004,7 +1000,6 @@ open class NSMutableData : NSData {
         super.init(data: data)
     }
 
-#if !os(WASI)
     public override init?(contentsOfFile path: String) {
         super.init(contentsOfFile: path)
     }
@@ -1020,7 +1015,6 @@ open class NSMutableData : NSData {
     public override init(contentsOf url: URL, options: NSData.ReadingOptions = []) throws {
         try super.init(contentsOf: url, options: options)
     }
-#endif
 
     public override init?(base64Encoded base64Data: Data, options: NSData.Base64DecodingOptions = []) {
         super.init(base64Encoded: base64Data, options: options)

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1373,7 +1373,6 @@ extension NSString {
         }
     }
 
-#if !os(WASI)
     public convenience init(contentsOf url: URL, encoding enc: UInt) throws {
         let readResult = try NSData(contentsOf: url, options: [])
 
@@ -1461,7 +1460,6 @@ extension NSString {
     public convenience init(contentsOfFile path: String, usedEncoding enc: UnsafeMutablePointer<UInt>?) throws {
         try self.init(contentsOf: URL(fileURLWithPath: path), usedEncoding: enc)
     }
-#endif
 }
 
 extension NSString : ExpressibleByStringLiteral { }

--- a/Sources/Foundation/NSStringAPI.swift
+++ b/Sources/Foundation/NSStringAPI.swift
@@ -331,7 +331,6 @@ extension String {
 
     //===--- Initializers that can fail -------------------------------------===//
 
-#if !os(WASI)
     // - (instancetype)
     //     initWithContentsOfFile:(NSString *)path
     //     encoding:(NSStringEncoding)enc
@@ -413,7 +412,6 @@ extension String {
         let ns = try NSString(contentsOf: url, usedEncoding: nil)
         self = String._unconditionallyBridgeFromObjectiveC(ns)
     }
-#endif
 
     // - (instancetype)
     //     initWithCString:(const char *)nullTerminatedCString


### PR DESCRIPTION
> This is a backport of https://github.com/swiftwasm/swift-corelibs-foundation/pull/545 to the swiftwasm-release/5.7 branch

This moves ifdefs around to compile a larger section of FileHandle. This makes it possible to use wasi features for reading stdin/stdout/stderr as well as some basic functionality to read from files.